### PR TITLE
Allow the user to supply a custom join_table name for authorization objects

### DIFF
--- a/lib/acl9/model_extensions.rb
+++ b/lib/acl9/model_extensions.rb
@@ -79,7 +79,7 @@ module Acl9
         role       = options[:role_class_name] || Acl9::config[:default_role_class_name]
         role_table = role.constantize.table_name
 
-        join_table = ActiveRecord::Base.send(:join_table_name, role_table, subj_table)
+        join_table = options[:join_table_name] || ActiveRecord::Base.send(:join_table_name, role_table, subj_table)
 
         sql_tables = <<-EOS
           FROM #{subj_table}


### PR DESCRIPTION
I have a subject named 'Client', and rails simply insists that I create the table with the name "clients_roles", but the `ActiveRecord::Base.send(:join_table_name, role_table, subj_table)` call you make on line 82 of model_extensions.rb returns "roles_clients".

I've dug around to try and find the root cause of the issue, but haven't been able to work it out.
My solution was to allow the model to supply it's own join table name if the user wants/needs to override it.

It still doesn't fix the issue, but it's a nifty work around.

Az
