### PR TITLE
Avoid N+1 problem when loading roles

### DIFF
--- a/lib/acl9/model_extensions/for_subject.rb
+++ b/lib/acl9/model_extensions/for_subject.rb
@@ -134,7 +134,7 @@ module Acl9
           lambda { |role| role.authorizable.nil? }
         else
           lambda do |role|
-            role.authorizable_type == object.class.base_class.to_s && role.authorizable == object
+            role.authorizable_type == object.class.base_class.to_s && role.authorizable_id == object.id
           end
         end
       end


### PR DESCRIPTION
Comparing `authorizable` prompts ActiveRecord to load it, each time individually. Eager loading could be employed, but I think an ID check is sufficient.
