### PR TITLE
Raise an error if the user passes invalid options to the allow or deny DSL methods

### DIFF
--- a/lib/acl9/controller_extensions/dsl_base.rb
+++ b/lib/acl9/controller_extensions/dsl_base.rb
@@ -88,8 +88,13 @@ module Acl9
       alias everybody all
       alias anyone all
 
+      def _permitted_allow_deny_option!(key)
+        raise ArgumentError, "#{key} is not a valid option" unless [:to, :except, :if, :unless, *VALID_PREPOSITIONS].include?(key.to_sym)
+      end
+
       def _parse_and_add_rule(*args)
         options = args.extract_options!
+        options.keys.each { |key| _permitted_allow_deny_option!(key) }
 
         _set_action_clause(options.delete(:to), options.delete(:except))
 


### PR DESCRIPTION
I spent a couple hours trying to figure out why someone else's code was permitting anyone to access the `checkin` action:

    access_control do
      allow all, :only => [:claim, :claimed]

      actions :checkin, :checkout do
        allow :admin
        allow :owner, :of => :event
      end
    end

Finally I realized it's because `:only => [:claim, :claimed]` does nothing. It should have been `:to => [:claim, :claimed]`. It'd be nice if the DSL would fail when you pass invalid options. This pull request adds a check to do that.

Please note that I wasn't able to get any tests to run on my machine (I gave up trying after hitting the third dependency issue), so the code is untested.
