### PR TITLE
Allow Rails 5.0

### DIFF
--- a/acl9.gemspec
+++ b/acl9.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "rails", '~> 4.0'
+  s.add_dependency "rails", '>= 4.0.0', '< 5.1'
 
   s.add_development_dependency "codeclimate-test-reporter"
   s.add_development_dependency "yard"


### PR DESCRIPTION
Rails 5.0.0.beta1 is released. I loosened up the dependency so acl9 can be used in Rails 5.0 projects.