### PR TITLE
split join query for big table

### DIFF
--- a/lib/acl9/model_extensions/for_subject.rb
+++ b/lib/acl9/model_extensions/for_subject.rb
@@ -177,7 +177,7 @@ module Acl9
       def delete_role(role)
         if role
           if ret = self._role_objects.delete(role)
-            if role.send(self._auth_subject_class_name.demodulize.tableize).empty?
+            if self.related_recocds_is_emprty_for_role?(role.id)
               ret &&= role.destroy unless role.respond_to?(:system?) && role.system?
             end
           end
@@ -205,6 +205,12 @@ module Acl9
 
       def _role_objects
         send(self._auth_role_assoc)
+      end
+
+      def related_recocds_is_emprty_for_role?(role_id)
+        join_table_name = "roles_#{self._auth_subject_class_name.demodulize.tableize}"
+        query_from_join_table = "Select * from #{join_table_name} where `role_id`=#{role_id}"
+        self.class.where(id: ActiveRecord::Base.connection.execute(query_from_join_table).map{|res| res[0]}).empty?
       end
     end
   end


### PR DESCRIPTION
why: in the case when we try to set has_no_role! . 
It calls inner join . If we have table with for more that 100 000 calculate count of records takes more than half of second.

how: instead of count result of inner join between roles and some_our_instance(USER) better to get roles_(users) - > get (user)_ids and check if that (users) exists.